### PR TITLE
Fix issue 5 - admin permissions

### DIFF
--- a/src/Admins/SearchAdmin.php
+++ b/src/Admins/SearchAdmin.php
@@ -13,7 +13,6 @@ use Firesphere\SolrSearch\Models\DirtyClass;
 use Firesphere\SolrSearch\Models\SearchSynonym;
 use Firesphere\SolrSearch\Models\SolrLog;
 use SilverStripe\Admin\ModelAdmin;
-use SilverStripe\Security\Security;
 use SilverStripe\View\Requirements;
 
 /**

--- a/src/Admins/SearchAdmin.php
+++ b/src/Admins/SearchAdmin.php
@@ -13,6 +13,7 @@ use Firesphere\SolrSearch\Models\DirtyClass;
 use Firesphere\SolrSearch\Models\SearchSynonym;
 use Firesphere\SolrSearch\Models\SolrLog;
 use SilverStripe\Admin\ModelAdmin;
+use SilverStripe\Security\Security;
 use SilverStripe\View\Requirements;
 
 /**
@@ -56,5 +57,13 @@ class SearchAdmin extends ModelAdmin
         parent::init();
 
         Requirements::css('firesphere/solr-search:client/dist/main.css');
+    }
+
+    protected function getManagedModelTabs()
+    {
+        $tabs = parent::getManagedModelTabs();
+        return $tabs->filterByCallback(function ($tab) {
+            return singleton($tab->ClassName)->canView();
+        });
     }
 }

--- a/src/Models/DirtyClass.php
+++ b/src/Models/DirtyClass.php
@@ -13,6 +13,8 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\ReadonlyField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\Permission;
+use SilverStripe\Security\PermissionProvider;
 
 /**
  * Class \Firesphere\SolrSearch\Models\DirtyClass
@@ -23,7 +25,7 @@ use SilverStripe\Security\Member;
  * @property string $Class
  * @property string $IDs
  */
-class DirtyClass extends DataObject
+class DirtyClass extends DataObject implements PermissionProvider
 {
     /**
      * @var string Table name
@@ -108,5 +110,38 @@ class DirtyClass extends DataObject
     public function canCreate($member = null, $context = [])
     {
         return false;
+    }
+
+    /**
+     * Member has view access?
+     *
+     * @param null|Member $member
+     * @return bool|mixed
+     */
+    public function canView($member = null)
+    {
+        return Permission::checkMember($member, 'VIEW_DIRTY_CLASSES');
+    }
+
+    /**
+     * Return a map of permission codes to add to the dropdown shown in the Security section of the CMS.
+     * array(
+     *   'VIEW_SITE' => 'View the site',
+     * );
+     *
+     * @return array
+     */
+    public function providePermissions()
+    {
+        return [
+            'VIEW_DIRTY_CLASSES'   => [
+                'name'     => _t(self::class . '.PERMISSION_VIEW_CLASSES_DESCRIPTION', 'View Solr dirty classes'),
+                'category' => _t('Permissions.LOGS_CATEGORIES', 'Solr logs permissions'),
+                'help'     => _t(
+                    self::class . '.PERMISSION_VIEW_CLASSES_HELP',
+                    'Permission required to view existing Solr dirty classes.'
+                ),
+            ],
+        ];
     }
 }

--- a/src/Models/SearchSynonym.php
+++ b/src/Models/SearchSynonym.php
@@ -108,7 +108,7 @@ class SearchSynonym extends DataObject implements PermissionProvider
     }
 
     /**
-     * Only createable by members with permission or when in dev mode to clean up
+     * Only createable by members with permission
      *
      * @param null|Member $member
      * @return boolean
@@ -119,7 +119,7 @@ class SearchSynonym extends DataObject implements PermissionProvider
     }
 
     /**
-     * Only editable by members with permission or when in dev mode to clean up
+     * Only editable by members with permission
      *
      * @param null|Member $member
      * @return boolean

--- a/src/Models/SearchSynonym.php
+++ b/src/Models/SearchSynonym.php
@@ -9,8 +9,11 @@
 
 namespace Firesphere\SolrSearch\Models;
 
+use Firesphere\SolrSearch\Admins\SearchAdmin;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Permission;
+use SilverStripe\Security\PermissionProvider;
 
 /**
  * Class \Firesphere\SolrSearch\Models\SearchSynonym
@@ -20,7 +23,7 @@ use SilverStripe\ORM\DataObject;
  * @property string $Keyword
  * @property string $Synonym
  */
-class SearchSynonym extends DataObject
+class SearchSynonym extends DataObject implements PermissionProvider
 {
     /**
      * @var string Table name
@@ -80,5 +83,71 @@ class SearchSynonym extends DataObject
     public function getCombinedSynonym()
     {
         return sprintf("\n%s,%s", $this->Keyword, $this->Synonym);
+    }
+
+    /**
+     * Member has view access?
+     *
+     * @param null|Member $member
+     * @return bool|mixed
+     */
+    public function canView($member = null)
+    {
+        return SearchAdmin::singleton()->canView($member);
+    }
+
+    /**
+     * Only deleteable by members with permission
+     *
+     * @param null|Member $member
+     * @return bool|mixed
+     */
+    public function canDelete($member = null)
+    {
+        return Permission::checkMember($member, 'EDIT_SYNONYMS');
+    }
+
+    /**
+     * Only createable by members with permission or when in dev mode to clean up
+     *
+     * @param null|Member $member
+     * @return boolean
+     */
+    public function canCreate($member = null, $context = [])
+    {
+        return Permission::checkMember($member, 'EDIT_SYNONYMS');
+    }
+
+    /**
+     * Only editable by members with permission or when in dev mode to clean up
+     *
+     * @param null|Member $member
+     * @return boolean
+     */
+    public function canEdit($member = null)
+    {
+        return Permission::checkMember($member, 'EDIT_SYNONYMS');
+    }
+
+    /**
+     * Return a map of permission codes to add to the dropdown shown in the Security section of the CMS.
+     * array(
+     *   'VIEW_SITE' => 'View the site',
+     * );
+     *
+     * @return array
+     */
+    public function providePermissions()
+    {
+        return [
+            'EDIT_SYNONYMS'   => [
+                'name'     => _t(self::class . '.PERMISSION_EDIT_SYNONYMS_DESCRIPTION', 'Edit Solr synonyms'),
+                'category' => _t('Permissions.LOGS_CATEGORIES', 'Solr logs permissions'),
+                'help'     => _t(
+                    self::class . '.PERMISSION_EDIT_SYNONYMS_HELP',
+                    'Permission required to create, edit and delete existing Solr synonyms.'
+                ),
+            ],
+        ];
     }
 }

--- a/src/Models/SolrLog.php
+++ b/src/Models/SolrLog.php
@@ -159,7 +159,6 @@ class SolrLog extends DataObject implements PermissionProvider
         return $classMap[$this->Level] ?? 'alert alert-info';
     }
 
-
     /**
      * Return a map of permission codes to add to the dropdown shown in the Security section of the CMS.
      * array(

--- a/src/Models/SolrLog.php
+++ b/src/Models/SolrLog.php
@@ -13,6 +13,7 @@ use SilverStripe\Control\Director;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
 
 /**
@@ -132,22 +133,18 @@ class SolrLog extends DataObject implements PermissionProvider
      */
     public function canView($member = null)
     {
-        return parent::canView($member);
+        return Permission::checkMember($member, 'VIEW_LOG');
     }
 
     /**
-     * Only deleteable by admins or when in dev mode to clean up
+     * Only deleteable by members with permission or when in dev mode to clean up
      *
      * @param null|Member $member
      * @return bool|mixed
      */
     public function canDelete($member = null)
     {
-        if ($member) {
-            return $member->inGroup('administrators') || Director::isDev();
-        }
-
-        return parent::canDelete($member) || Director::isDev();
+        return Permission::checkMember($member, 'DELETE_LOG') || Director::isDev();
     }
 
     /**


### PR DESCRIPTION
Fix for [issue #5](https://github.com/signify-nz/silverstripe-solr/issues/5). Covers:

- Use existing permission options as per their descriptions for SolrLog objects. Note: as per previous behaviour, the delete permission for SolrLog objects will always return true in Dev environments.
- Create new permissions: one each for editing SolrSynonym and viewing DirtyClass objects
- Remove any tabs from the Search admin area where the current member does not have permission to view the objects within the tab.